### PR TITLE
Add source map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ An object of options that will be passed to the instrumenter.
 
 Default value:
 
-```
-{ 
-  esModules: true
+```js
+{
+  esModules: true,
+  codeGenerationOptions: {
+    sourceMap: id,
+    sourceMapWithCode: true
+  }
 }
 ```
 
@@ -67,9 +71,9 @@ Can be a replacement for the istanbul library, for example [isparta](https://git
 
 ### Other usage options
 
-`rollup-plugin-istanbul` can be used with karma or other test runners that allow preprocessors. Here you can see how to implement it with Karma with the help of the [karma-rollup-preprocessor](https://github.com/showpad/karma-rollup-preprocessor):
+`rollup-plugin-istanbul` can be used with karma or other test runners that allow preprocessors. Here you can see how to implement it with Karma with the help of the [karma-rollup-preprocessor](https://github.com/showpad/karma-rollup-preprocessor) and [karma-coverage](https://github.com/karma-runner/karma-coverage):
 
-```
+```js
 // karma.conf.js
 module.exports = function (config) {
   config.set({
@@ -87,14 +91,15 @@ module.exports = function (config) {
           })
         ]
       }
-    }
+    },
+    reporters: ['coverage']
   });
 };
 ```
 
-Going further, this is how you can implement it when you are using babel because you are writting ES2015 code:
+Going further, this is how you can implement it when you are using babel because you are writing ES2015 code:
 
-```
+```js
 // karma.conf.js
 module.exports = function (config) {
   config.set({
@@ -107,20 +112,21 @@ module.exports = function (config) {
     rollupPreprocessor: {
       rollup: {
         plugins: [
+          require('rollup-plugin-istanbul')({
+            exclude: ['test/*.js']
+          }),
           require('rollup-plugin-babel')({
             presets: [
               require('babel-preset-es2015-rollup')
             ]
-          }),
-          require('rollup-plugin-istanbul')({
-            exclude: ['test/*.js']
           })
         ]
       },
       bundle: {
         sourceMap: 'inline'
       }
-    }
+    },
+    reporters: ['coverage']
   });
 };
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ export default function (options = {}) {
       if (!filter(id)) return;
 
       var InstrumenterImpl = (options.instrumenter || istanbul).Instrumenter;
-      var instrumenterOptions = options.instrumenterConfig || { };
+      var instrumenterOptions = options.instrumenterConfig || {};
       if (!('esModules' in instrumenterOptions)) {
         instrumenterOptions.esModules = true;
       }
 
-      instrumenterOptions.codeGenerationOptions = instrumenter.codeGenerationOptions || {
+      instrumenterOptions.codeGenerationOptions = instrumenterOptions.codeGenerationOptions || {
         sourceMap: id,
         sourceMapWithCode: true
       };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,10 @@ export default function (options = {}) {
     transform (code, id) {
       if (!filter(id)) return;
 
-      var instrumenter = new (options.instrumenter || istanbul).Instrumenter(options.instrumenterConfig || { esModules: true });
+      var InstrumenterImpl = (options.instrumenter || istanbul).Instrumenter;
+      var instrumenterOptions = options.instrumenterConfig || { esModules: true };
+
+      var instrumenter = new InstrumenterImpl(instrumenterOptions);
 
       code = instrumenter.instrumentSync(code, id);
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ export default function (options = {}) {
       if (!filter(id)) return;
 
       var InstrumenterImpl = (options.instrumenter || istanbul).Instrumenter;
-      var instrumenterOptions = options.instrumenterConfig || { esModules: true };
+      var instrumenterOptions = options.instrumenterConfig || { };
+      if (!('esModules' in instrumenterOptions)) {
+        instrumenterOptions.esModules = true;
+      }
 
       var instrumenter = new InstrumenterImpl(instrumenterOptions);
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,14 +14,19 @@ export default function (options = {}) {
         instrumenterOptions.esModules = true;
       }
 
+      instrumenterOptions.codeGenerationOptions = instrumenter.codeGenerationOptions || {
+        sourceMap: id,
+        sourceMapWithCode: true
+      };
+
       var instrumenter = new InstrumenterImpl(instrumenterOptions);
 
       code = instrumenter.instrumentSync(code, id);
 
-      return {
-        code,
-        map: { mappings: '' }
-      };
+      var map = instrumenter.lastSourceMap();
+      map = map ? map.toJSON() : { mappings: '' };
+
+      return { code, map };
     }
   };
 }


### PR DESCRIPTION
Adds source maps to the instrumented code.

Before:
```
  SomeClass
    ✖ does a thing
      Chrome 50.0.2661
    TypeError: Cannot read property 'thing' of null
        at SomeClass.doThing (PROJECT_ROOT/node_modules/lodash/lodash.js:16149:15)
        at Context.<anonymous> (PROJECT_ROOT/test/someClass_test.js:10:12)
```
(notice the error occurs in some random line in some random node module instead of in our source code)

After
```
  SomeClass
    ✖ does a thing
      Chrome 50.0.2661
    TypeError: Cannot read property 'thing' of null
        at SomeClass.doThing (PROJECT_ROOT/src/someClass.js:10:9)
        at Context.<anonymous> (PROJECT_ROOT/test/someClass_test.js:10:12)
```
(after the changes, we get proper line numbers and files)