### PR TITLE
Use rollup targets to speed up the build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "rm -rf dist/*",
-    "build": "rollup -c -f cjs -o dist/rollup-plugin-istanbul.cjs.js && rollup -c -f es6 -o dist/rollup-plugin-istanbul.es6.js",
+    "build": "rollup -c",
     "pretest": "npm run build",
     "test": "eslint src/index.js test/*.js && mocha",
     "prepublish": "npm test"
@@ -38,7 +38,7 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "eslint": "^1.10.3",
     "mocha": "^2.3.4",
-    "rollup": "^0.25.1",
+    "rollup": "^0.30.0",
     "rollup-plugin-babel": "^2.3.9"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,5 +3,15 @@ import babel from 'rollup-plugin-babel'
 export default {
   entry: 'src/index.js',
   plugins: [babel()],
-  external: ['istanbul', 'rollup-pluginutils']
+  external: ['istanbul', 'rollup-pluginutils'],
+  targets: [
+    {
+      format: 'cjs',
+      dest: 'dist/rollup-plugin-istanbul.cjs.js'
+    },
+    {
+      format: 'es6',
+      dest: 'dist/rollup-plugin-istanbul.es6.js'
+    }
+  ]
 }


### PR DESCRIPTION
This also pulls in other changes between 0.25.1 and 0.30.0, notably support for the `__esModule` flag.