### PR TITLE
Fix the jsnext:main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Seamless integration between Rollup and Istanbul.",
   "main": "dist/rollup-plugin-istanbul.cjs.js",
-  "jsnext:main": "dist/rollup-plugin-istanbul.es6.js",
+  "jsnext:main": "dist/rollup-plugin-istanbul.es.js",
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The path output filename was changed in https://github.com/artberri/rollup-plugin-istanbul/commit/6472f2fe557c95ba3970695dc1443f736959884b, but the property in the `package.json` was not updated.

This PR changes the `jsnext:main` path to use `es.js` so it matches the rollup config.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #18 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want this module to resolve correctly when using `eslint-plugin-import` and `eslint-import-resolver-node`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I changed the value locally and everything worked as expected.